### PR TITLE
Enable urlquote wrapper around user in engine_str call

### DIFF
--- a/dslib/sql/engine.py
+++ b/dslib/sql/engine.py
@@ -30,10 +30,10 @@ class EngineContext:
             ) from key_error
 
         if self.driver is not None:
-            self.engine_str = f"{dialect}+{self.driver}://{user}:{urlquote(password)}@{host}:{port}/{dbname}"
+            self.engine_str = f"{dialect}+{self.driver}://{urlquote(user)}:{urlquote(password)}@{host}:{port}/{dbname}"
         else:
             self.engine_str = (
-                f"{dialect}://{user}:{urlquote(password)}@{host}:{port}/{dbname}"
+                f"{dialect}://{urlquote(user)}:{urlquote(password)}@{host}:{port}/{dbname}"
             )
 
         self.engine = sqlalchemy.create_engine(self.engine_str)


### PR DESCRIPTION
Long time user, first time contributor. Opening this PR to envelope the user name portion of the connection string in urlquote. Doing so solves an error that arises when using temporary RedShift credentials to connect to DBs. Specifically, I've found the temp user features a `:` special character that leads to errors associated with the connection string.  